### PR TITLE
CouenneProblem: mark more operators as constant

### DIFF
--- a/src/problem/CouenneProblem.hpp
+++ b/src/problem/CouenneProblem.hpp
@@ -74,7 +74,7 @@ class Nauty;
 #define COUENNE_EPS_SYMM 1e-8
 
   struct myclass0 {
-    inline bool operator() (register const Node &a, register const Node &b) {
+    inline bool operator() (register const Node &a, register const Node &b) const {
 
       return ((               a.get_code  () <  b.get_code  ())                     ||
 	      ((              a.get_code  () == b.get_code  ()                      &&
@@ -120,7 +120,7 @@ class Nauty;
     
       
   struct myclass {
-    inline bool operator() (register const  Node &a, register const Node &b) {
+    inline bool operator() (register const  Node &a, register const Node &b) const {
       return (a.get_index() < b.get_index() );
     }
   };


### PR DESCRIPTION
Reported downstream in Gentoo with GCC 11. We
ended up duplicating efforts a tiny bit as we
originally changed both instances in the codebase,
but one has already been fixed.

See: fdfe17562c59518b4db478ca51c18ab5e01a59a5
Bug: https://bugs.gentoo.org/792798

Signed-off-by: Sam James <sam@gentoo.org>